### PR TITLE
Añadir método GetBase64 en DocumentsController

### DIFF
--- a/Backend/Controllers/DocumentsController.cs
+++ b/Backend/Controllers/DocumentsController.cs
@@ -60,5 +60,13 @@ namespace Backend.Controllers
             var isSuccess = await _documentService.DeleteDocuments(ids);
             return Ok(new { isSuccess });
         }
+
+        [HttpGet]
+        [Route("getBase64")]
+        public async Task<IActionResult> GetBase64(int id)
+        {
+            var document = await _documentService.GetBase64(id);
+            return Ok(new { value = document });
+        }
     }
 }


### PR DESCRIPTION
Se ha añadido un nuevo método `GetBase64` en el controlador `DocumentsController` dentro del espacio de nombres `Backend.Controllers`. Este método HTTP GET recibe un parámetro `id` de tipo entero, llama al servicio `_documentService` para obtener el documento en formato Base64 utilizando el `id` proporcionado y devuelve una respuesta HTTP 200 (OK) con el documento en formato Base64 encapsulado en un objeto JSON.