### PR TITLE
Añadir método GetDocument en controlador y servicio

### DIFF
--- a/Backend/Controllers/DocumentsController.cs
+++ b/Backend/Controllers/DocumentsController.cs
@@ -68,5 +68,13 @@ namespace Backend.Controllers
             var document = await _documentService.GetBase64(id);
             return Ok(new { value = document });
         }
+
+        [HttpGet]
+        [Route("getDocument")]
+        public async Task<IActionResult> GetDocument(int id)
+        {
+            var document = await _documentService.GetDocument(id);
+            return Ok(new { value = document });
+        }
     }
 }

--- a/Backend/Services/DocumentServices.cs
+++ b/Backend/Services/DocumentServices.cs
@@ -89,6 +89,11 @@ namespace Backend.Services
             _context.Documents.Update(document);
             return await _context.SaveChangesAsync() > 0;
         }
+
+        public async Task<Document?> GetDocument(int id)
+        {
+            return await _context.Documents.FindAsync(id);
+        }
     }
 }
 


### PR DESCRIPTION
Se ha añadido un nuevo endpoint HTTP GET llamado `GetDocument` en `DocumentsController.cs` que permite obtener un documento específico basado en su ID.

En `DocumentServices.cs`, se ha añadido un método `GetDocument` que interactúa con la base de datos para encontrar y devolver un documento por su ID.